### PR TITLE
Add admin management for discharge types

### DIFF
--- a/tareas/admin/Forms/form_tipo_alta.py
+++ b/tareas/admin/Forms/form_tipo_alta.py
@@ -1,0 +1,39 @@
+from django import forms
+from django.utils import timezone
+from django.core.exceptions import ValidationError
+import re
+from tareas.models import Tiposalta
+
+class TipoAltaForm(forms.ModelForm):
+    class Meta:
+        model = Tiposalta
+        fields = ['nombre', 'descripcion', 'estado', 'fechacreacion']
+        widgets = {
+            'fechacreacion': forms.DateTimeInput(attrs={'type': 'datetime-local'})
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['estado'] = forms.TypedChoiceField(
+            choices=[(True, 'Activo'), (False, 'Inactivo')],
+            coerce=lambda x: x == 'True',
+            empty_value=None
+        )
+        self.fields['nombre'].widget.attrs.update({
+            'pattern': r'[A-Za-zÁÉÍÓÚáéíóúÑñ ]+',
+            'title': 'Solo letras'
+        })
+
+    def save(self, commit=True):
+        obj = super().save(commit=False)
+        if not obj.fechacreacion:
+            obj.fechacreacion = timezone.now()
+        if commit:
+            obj.save()
+        return obj
+
+    def clean_nombre(self):
+        nombre = self.cleaned_data.get('nombre', '')
+        if not re.fullmatch(r'[A-Za-zÁÉÍÓÚáéíóúÑñ ]+', nombre):
+            raise ValidationError('El nombre debe contener solo letras.')
+        return nombre

--- a/tareas/admin/templates/admin/MenuAdmin.html
+++ b/tareas/admin/templates/admin/MenuAdmin.html
@@ -24,6 +24,7 @@
             <li><i class="bi bi-journal-medical"></i> Gestión de Especialidades</li>
             <li><i class="bi bi-clipboard2-pulse-fill"></i> Servicios Médicos</li>
             <li><i class="bi bi-door-closed-fill"></i> Gestión de Habitaciones</li>
+            <li><i class="bi bi-person-check-fill"></i> Gestión de Altas</li>
             <li><i class="bi bi-credit-card-2-back-fill"></i> Métodos de Pago</li>
             <li><i class="bi bi-person-lines-fill"></i> Control de Pacientes</li>
             <li><i class="bi bi-hospital"></i> Consultas y Emergencias</li>

--- a/tareas/admin/templates/admin/listar_tipos_alta.html
+++ b/tareas/admin/templates/admin/listar_tipos_alta.html
@@ -1,0 +1,42 @@
+{% extends 'admin/MenuAdmin.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'admin/css/listar_personal.css' %}">
+{% endblock %}
+
+{% block title %}Tipos de Alta - BioSalud{% endblock %}
+
+{% block contenido %}
+<div class="listado-card">
+    <h2>Tipos de Alta</h2>
+    <div class="top-actions">
+        <a href="{% url 'registrar_tipoalta' %}" class="btn-nuevo">+ Nuevo tipo</a>
+    </div>
+    <div class="tabla-scroll">
+        <table class="tabla-personal">
+            <thead>
+                <tr>
+                    <th>Nombre</th>
+                    <th>Estado</th>
+                    <th>Acciones</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for t in tipos %}
+                <tr>
+                    <td>{{ t.nombre }}</td>
+                    <td class="{{ t.estado|yesno:'activo,inactivo'|lower }}">{{ t.estado|yesno:"Activo,Inactivo" }}</td>
+                    <td>
+                        <a href="{% url 'editar_tipoalta' t.tipoaltaid %}" class="action-icon edit" title="Editar"><i class="bi bi-pencil-square"></i> Editar</a>
+                        <a href="{% url 'eliminar_tipoalta' t.tipoaltaid %}" class="action-icon delete" title="Eliminar" onclick="return confirm('¿Eliminar este tipo?');"><i class="bi bi-trash-fill"></i> Eliminar</a>
+                    </td>
+                </tr>
+                {% empty %}
+                <tr><td colspan="3">No hay tipos registrados</td></tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/tareas/admin/templates/admin/registrar_tipoalta.html
+++ b/tareas/admin/templates/admin/registrar_tipoalta.html
@@ -1,0 +1,30 @@
+{% extends 'admin/MenuAdmin.html' %}
+{% load static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'admin/css/registrar_personal.css' %}">
+{% endblock %}
+
+{% block title %}Registrar Tipo de Alta - BioSalud{% endblock %}
+
+{% block contenido %}
+<div class="form-card">
+    <h2>Registrar Tipo de Alta</h2>
+    {% if messages %}
+    {% for message in messages %}
+    <div class="alert {{ message.tags }}">{{ message }}</div>
+    {% endfor %}
+    {% endif %}
+    <form method="post" class="form-grid">
+        {% csrf_token %}
+        <div class="form-field">{{ form.nombre.label_tag }}{{ form.nombre }}</div>
+        <div class="form-field">{{ form.descripcion.label_tag }}{{ form.descripcion }}</div>
+        <div class="form-field">{{ form.estado.label_tag }}{{ form.estado }}</div>
+        <div class="form-field"></div>
+        <div class="form-full">
+            <button type="submit" class="btn-guardar">Guardar</button>
+        </div>
+    </form>
+    <a href="{% url 'listar_tipos_alta' %}" class="volver">← Volver al listado</a>
+</div>
+{% endblock %}

--- a/tareas/admin/urls_admin.py
+++ b/tareas/admin/urls_admin.py
@@ -14,6 +14,7 @@ from .views_admin import (
     listar_habitaciones, registrar_habitacion, editar_habitacion, eliminar_habitacion,
     listar_tipos_habitacion, registrar_tipohabitacion, editar_tipohabitacion, eliminar_tipohabitacion,
     listar_metodos_pago, registrar_metodo_pago, editar_metodo_pago, eliminar_metodo_pago,
+    listar_tipos_alta, registrar_tipoalta, editar_tipoalta, eliminar_tipoalta,
     inicio_admin
 )
 
@@ -55,6 +56,10 @@ urlpatterns = [
     path('metodos_pago/nuevo/', registrar_metodo_pago, name='registrar_metodo_pago'),
     path('metodos_pago/<int:metodo_id>/editar/', editar_metodo_pago, name='editar_metodo_pago'),
     path('metodos_pago/<int:metodo_id>/eliminar/', eliminar_metodo_pago, name='eliminar_metodo_pago'),
+    path('tipos_alta/', listar_tipos_alta, name='listar_tipos_alta'),
+    path('tipos_alta/nueva/', registrar_tipoalta, name='registrar_tipoalta'),
+    path('tipos_alta/<int:alta_id>/editar/', editar_tipoalta, name='editar_tipoalta'),
+    path('tipos_alta/<int:alta_id>/eliminar/', eliminar_tipoalta, name='eliminar_tipoalta'),
     path('consultas/', listar_consultas, name='listar_consultas'),
     path('consultas/<int:consulta_id>/', detalle_consulta, name='detalle_consulta'),
     path('reportes/', reportes_estadisticas, name='reportes_estadisticas'),

--- a/tareas/admin/views_admin.py
+++ b/tareas/admin/views_admin.py
@@ -5,12 +5,13 @@ from tareas.admin.Forms.form_especialidad import EspecialidadForm
 from tareas.admin.Forms.form_servicio import ServicioForm
 from tareas.admin.Forms.form_habitacion import HabitacionForm, TipoHabitacionForm
 from tareas.admin.Forms.form_metodo_pago import MetodoPagoForm
+from tareas.admin.Forms.form_tipo_alta import TipoAltaForm
 from tareas.admin.Forms.form_config import ConfiguracionForm
 from tareas.admin.config_utils import load_config, save_config
 from tareas.models import (
     Personal, Pacientes, PacienteAudit, Especialidades,
     Servicios, Facturas, Pagos, Consultas, Consultaservicios,
-    Habitaciones, Tiposhabitacion, Metodospago,
+    Habitaciones, Tiposhabitacion, Metodospago, Tiposalta,
     Fichaclinico, Hospitalizaciones
 )
 from django.contrib.auth.hashers import make_password
@@ -505,6 +506,62 @@ def eliminar_metodo_pago(request, metodo_id):
     metodo.delete()
     messages.success(request, 'Método de pago eliminado.')
     return redirect('listar_metodos_pago')
+
+
+# ----------------------------
+# GESTIÓN DE TIPOS DE ALTA
+# ----------------------------
+def listar_tipos_alta(request):
+    tipos = Tiposalta.objects.all()
+    return render(request, 'admin/listar_tipos_alta.html', {
+        'tipos': tipos,
+        'nombre': request.session.get('nombre'),
+        'rol': request.session.get('rol'),
+    })
+
+
+def registrar_tipoalta(request):
+    if request.method == 'POST':
+        form = TipoAltaForm(request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Tipo de alta guardado.')
+            return redirect('listar_tipos_alta')
+        else:
+            messages.error(request, 'Revisa los campos del formulario.')
+    else:
+        form = TipoAltaForm()
+    return render(request, 'admin/registrar_tipoalta.html', {
+        'form': form,
+        'nombre': request.session.get('nombre'),
+        'rol': request.session.get('rol'),
+    })
+
+
+def editar_tipoalta(request, alta_id):
+    tipo = Tiposalta.objects.get(pk=alta_id)
+    if request.method == 'POST':
+        form = TipoAltaForm(request.POST, instance=tipo)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Tipo de alta actualizado.')
+            return redirect('listar_tipos_alta')
+        else:
+            messages.error(request, 'Revisa los campos del formulario.')
+    else:
+        form = TipoAltaForm(instance=tipo)
+    return render(request, 'admin/registrar_tipoalta.html', {
+        'form': form,
+        'nombre': request.session.get('nombre'),
+        'rol': request.session.get('rol'),
+    })
+
+
+def eliminar_tipoalta(request, alta_id):
+    tipo = Tiposalta.objects.get(pk=alta_id)
+    tipo.delete()
+    messages.success(request, 'Tipo de alta eliminado.')
+    return redirect('listar_tipos_alta')
 
 
 # ----------------------------

--- a/tareas/static/admin/js/MenuAdmin.js
+++ b/tareas/static/admin/js/MenuAdmin.js
@@ -35,6 +35,8 @@ document.addEventListener("DOMContentLoaded", function () {
                 window.location.href = "/admin/servicios/";
             } else if (opcion === "Gestión de Habitaciones") {
                 window.location.href = "/admin/habitaciones/";
+            } else if (opcion === "Gestión de Altas") {
+                window.location.href = "/admin/tipos_alta/";
             } else if ( opcion === "Métodos de Pago") {
                 window.location.href = "/admin/metodos_pago/";
             } else if (opcion === "Control de Pacientes") {


### PR DESCRIPTION
## Summary
- add form for `Tiposalta`
- implement CRUD views for discharge types
- expose endpoints in admin URLs
- create templates to list and register discharge types
- add sidebar navigation and JS handler for new menu entry

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_686b7baf4e688328b3390d45903d2aba